### PR TITLE
Remove custom input to configure shortcut

### DIFF
--- a/options/options.html
+++ b/options/options.html
@@ -11,6 +11,8 @@
       <p>
       <strong>Notice: </strong>
       Custom shortcut configuration was retired in favor of <a href="https://support.mozilla.org/en-US/kb/manage-extension-shortcuts-firefox" target="_blank">Firefox own configuration tool</a>
+      <br/>
+      If you have previously set a custom shortcut, this configuration was kept.
       </p>
     </div>
     <form id="form">

--- a/options/options.html
+++ b/options/options.html
@@ -7,17 +7,14 @@
   </head>
 
   <body>
+    <div id="shortcutWarning">
+      <p>
+      <strong>Notice: </strong>
+      Custom shortcut configuration was retired in favor of <a href="https://support.mozilla.org/en-US/kb/manage-extension-shortcuts-firefox" target="_blank">Firefox own configuration tool</a>
+      </p>
+    </div>
     <form id="form">
       <div class="half pull-left">
-        <div id="shortcutBlock" class="optionBlock">
-          <label for="shortcut">Keyboard shortcut:</label>
-          <label><input type="radio" name="modifier" value="Alt"> Alt</label>
-          <label><input type="radio" name="modifier" value="MacCtrl"> Ctrl</label>
-          <label><input type="radio" name="modifier" value="Command"> Cmd</label>
-          <label><input type="checkbox" name="shift" value="Shift"> Shift</label>
-          <input type="text" id="shortcut">
-          <button id="reset_shortcut">Reset</button>
-        </div>
         <div id="limitBlock" class="optionBlock">
           <label for="lists">Number of results:</label>
           <label><input type="number" name="limit" value="100" min="1"> per group</label>

--- a/options/options.js
+++ b/options/options.js
@@ -1,6 +1,5 @@
 /* global getLimit */
 
-const commandName = 'quick-commands'
 const themes = {
   default: {
     'main-bg-color': '#ececec',
@@ -21,10 +20,6 @@ const themes = {
 }
 
 let selectedTheme = themes.default
-
-const commandUpdateSupported = () => {
-  return Object.prototype.hasOwnProperty.call(browser.commands, 'update')
-}
 
 const getTheme = (themeName) => {
   if (themeName === 'custom') {
@@ -47,9 +42,6 @@ const save = (event) => {
     themeName,
     limit: getLimitValue()
   })
-  if (commandUpdateSupported()) {
-    updateShortcut()
-  }
   return false
 }
 
@@ -95,54 +87,12 @@ const restoreOptions = async () => {
   }
   doUpdatePreview(theme)
   await updateLimitUI()
-
-  if (commandUpdateSupported()) {
-    await updateShortcutUI()
-  }
 }
 
 const updatePreviewProperty = (event) => {
   const input = event.target
   const preview = document.getElementById('preview')
   preview.style.setProperty('--' + input.getAttribute('id'), input.value)
-}
-
-const updateShortcut = () => {
-  const activator = document.querySelector('#shortcut').value
-  const modifiers = Array.from(document.querySelectorAll('#shortcutBlock input[name=\'modifier\'], #shortcutBlock input[name=\'shift\']'))
-    .filter(f => f.checked)
-    .map(f => f.value)
-  modifiers.push(activator)
-  const shortcut = modifiers.join('+')
-
-  browser.commands.update({
-    name: commandName,
-    shortcut
-  })
-}
-
-const updateShortcutUI = async () => {
-  document.getElementById('shortcutBlock').style.display = 'block'
-  const commands = await browser.commands.getAll()
-  for (const command of commands) {
-    if (command.name === commandName) {
-      populateShortcutSettings(command.shortcut)
-    }
-  }
-}
-
-const populateShortcutSettings = (shortcut) => {
-  const keys = shortcut.split('+')
-  const activator = keys.pop()
-  keys.forEach(modifier => {
-    document.querySelector(`#shortcutBlock input[value='${modifier}']`).setAttribute('checked', true)
-  })
-  document.querySelector('#shortcut').value = activator
-}
-
-const resetShortcut = () => {
-  browser.commands.reset(commandName)
-  updateShortcutUI()
 }
 
 const getLimitValue = () => {
@@ -157,7 +107,6 @@ const start = () => {
   document.getElementById('form').addEventListener('submit', save)
   document.getElementById('theme').addEventListener('change', toggleCustomColors)
   document.getElementById('theme').addEventListener('change', updateLivePreview)
-  document.getElementById('reset_shortcut').addEventListener('click', resetShortcut)
   for (const input of document.querySelectorAll('input[type=color]')) {
     input.addEventListener('change', updatePreviewProperty)
   }


### PR DESCRIPTION
The current custom input to configure the extension shortcut is quite bugged, plus there is a global Firefox option page for managing extension shortcuts, so we are removing the option inside the extension page and linking to the documentation regarding this existing internal page